### PR TITLE
build: bump gnome-shell dependency to >= 42.0

### DIFF
--- a/build-aux/misc/gnome-shell-extension-valent.spec
+++ b/build-aux/misc/gnome-shell-extension-valent.spec
@@ -1,7 +1,7 @@
 %global tarball_version %%(echo %{version} | tr '~' '.')
 %global debug_package %{nil}
 
-%global gnome_shell_version 3.38.0
+%global gnome_shell_version 42.0
 %global libpeas_version     1.22.0
 %global valent_version      1.0.0.alpha
 
@@ -50,6 +50,6 @@ bundled Python plugin is used by Valent to communicate with the extension.
 %{_libdir}/valent/plugins/
 
 %changelog
-* Wed May 18 2022 Andy Holmes <andrew.g.r.holmes@gmail.com> - 1-1
+* Fri Jun 17 2022 Andy Holmes <andrew.g.r.holmes@gmail.com> - 1-1
 - Initial release
 

--- a/src/extension/clipboard.js
+++ b/src/extension/clipboard.js
@@ -4,7 +4,6 @@
 
 /* exported Clipboard */
 
-const ByteArray = imports.byteArray;
 const { GLib, GjsPrivate, Gio, GObject, Meta } = imports.gi;
 
 
@@ -62,11 +61,10 @@ const TEXT_MIMETYPES = [
 var Clipboard = GObject.registerClass({
     GTypeName: 'ValentClipboard',
 }, class ValentClipboard extends GjsPrivate.DBusImplementation {
-    _init() {
-        super._init({
-            g_interface_info: DBUS_INFO,
-        });
+    constructor() {
+        super({ g_interface_info: DBUS_INFO });
 
+        this._decoder = new TextDecoder('utf-8', { fatal: true });
         this._selection = global.display.get_selection();
         this._serviceOwner = null;
         this._transferring = false;
@@ -257,7 +255,7 @@ var Clipboard = GObject.registerClass({
                             const bytes = stream.steal_as_bytes();
                             const bytearray = bytes.get_data();
 
-                            resolve(ByteArray.toString(bytearray));
+                            resolve(this._decoder.decode(bytearray));
                         } catch (e) {
                             reject(e);
                         }

--- a/src/extension/device.js
+++ b/src/extension/device.js
@@ -49,8 +49,8 @@ var Battery = GObject.registerClass({
         ),
     },
 }, class Battery extends St.BoxLayout {
-    _init(params) {
-        super._init(Object.assign({
+    constructor(params) {
+        super(Object.assign({
             style_class: 'valent-device-battery',
         }, params));
 

--- a/src/extension/extension.js
+++ b/src/extension/extension.js
@@ -78,8 +78,8 @@ function installPlugin() {
 const ServiceIndicator = GObject.registerClass({
     GTypeName: 'ValentServiceIndicator',
 }, class ServiceIndicator extends PanelMenu.SystemIndicator {
-    _init() {
-        super._init();
+    constructor() {
+        super();
 
         this._devices = new WeakMap();
         this.connect('destroy', this._onDestroy);

--- a/src/extension/metadata.json.in
+++ b/src/extension/metadata.json.in
@@ -5,6 +5,6 @@
     "gettext-domain": "@GETTEXT_DOMAIN@",
     "version": @EXTENSION_VERSION@,
     "session-modes": ["unlock-dialog", "user"],
-    "shell-version": ["3.38", "40.0", "41", "42"],
+    "shell-version": ["42"],
     "url": "https://github.com/andyholmes/gnome-shell-extension-valent"
 }

--- a/src/extension/notification.js
+++ b/src/extension/notification.js
@@ -28,8 +28,8 @@ const _pushNotification = NotificationDaemon.GtkNotificationDaemonAppSource.prot
 const NotificationBanner = GObject.registerClass({
     GTypeName: 'ValentNotificationBanner',
 }, class NotificationBanner extends MessageTray.NotificationBanner {
-    _init(notification) {
-        super._init(notification);
+    constructor(notification) {
+        super(notification);
 
         if (this.notification._defaultAction === 'app.device') {
             const [
@@ -317,10 +317,6 @@ function _onSourceAdded(messageTray, source) {
 
 /** */
 function _patchValentNotificationSource() {
-    // This should only happen on versions of GNOME Shell older than GNOME 42
-    if (_sourceAddedId)
-        return;
-
     const source = Main.notificationDaemon._gtkNotificationDaemon._sources[APP_ID];
 
     if (source !== undefined) {

--- a/src/extension/remote.js
+++ b/src/extension/remote.js
@@ -123,8 +123,8 @@ var Device = GObject.registerClass({
         ),
     },
 }, class Device extends Gio.DBusProxy {
-    _init(service, objectPath) {
-        super._init({
+    constructor(service, objectPath) {
+        super({
             g_connection: service.g_connection,
             g_name: SERVICE_NAME,
             g_object_path: objectPath,
@@ -223,8 +223,8 @@ var Service = GObject.registerClass({
         },
     },
 }, class Service extends Gio.DBusProxy {
-    _init() {
-        super._init({
+    constructor() {
+        super({
             g_bus_type: Gio.BusType.SESSION,
             g_name: SERVICE_NAME,
             g_object_path: SERVICE_PATH,


### PR DESCRIPTION
This brings with it a bump to GJS >= 1.72, which includes new language
features and, of course, bug fixes.