### PR TITLE
refactor: remove the "connected" property

### DIFF
--- a/src/extension/remote.js
+++ b/src/extension/remote.js
@@ -71,13 +71,6 @@ var Device = GObject.registerClass({
     GTypeName: 'ValentRemoteDevice',
     Implements: [Gio.DBusInterface],
     Properties: {
-        'connected': GObject.ParamSpec.boolean(
-            'connected',
-            'Connected',
-            'Whether the device is connected',
-            GObject.ParamFlags.READABLE,
-            false
-        ),
         'icon-name': GObject.ParamSpec.string(
             'icon-name',
             'Icon Name',
@@ -128,7 +121,6 @@ var Device = GObject.registerClass({
     on_g_properties_changed(changed, _invalidated) {
         try {
             const properties = {
-                'Connected': 'connected',
                 'IconName': 'icon-name',
                 'Id': 'id',
                 'Name': 'name',
@@ -150,10 +142,6 @@ var Device = GObject.registerClass({
             return value.unpack();
 
         return fallback;
-    }
-
-    get connected() {
-        return this._get('Connected', false);
     }
 
     get icon_name() {


### PR DESCRIPTION
This removes the `Valent.Device:connected` property from the device
proxy class, which will be removed from public API in Valent shortly.

Depends on andyholmes/valent#231