### PR TITLE
fix(clipboard): address some potential concurrency issues

### DIFF
--- a/src/extension/clipboard.js
+++ b/src/extension/clipboard.js
@@ -142,8 +142,7 @@ var Clipboard = GObject.registerClass({
                 const args = DBUS_INFO.lookup_method(name).out_args;
                 retval = new GLib.Variant(
                     `(${args.map(arg => arg.signature).join('')})`,
-                    args.length === 1 ? [retval] : retval
-                );
+                    args.length === 1 ? [retval] : retval);
             }
 
             invocation.return_value(retval);

--- a/src/extension/clipboard.js
+++ b/src/extension/clipboard.js
@@ -64,6 +64,7 @@ var Clipboard = GObject.registerClass({
     constructor() {
         super({ g_interface_info: DBUS_INFO });
 
+        this._cancellable = new Gio.Cancellable();
         this._decoder = new TextDecoder('utf-8', { fatal: true });
         this._selection = global.display.get_selection();
         this._serviceOwner = null;
@@ -245,7 +246,8 @@ var Clipboard = GObject.registerClass({
                 this._selection.transfer_async(
                     Meta.SelectionType.SELECTION_CLIPBOARD,
                     mimetype, -1,
-                    stream, null,
+                    stream,
+                    this._cancellable,
                     (selection, res) => {
                         try {
                             selection.transfer_finish(res);
@@ -307,7 +309,8 @@ var Clipboard = GObject.registerClass({
             this._selection.transfer_async(
                 Meta.SelectionType.SELECTION_CLIPBOARD,
                 mimetype, -1,
-                stream, null,
+                stream,
+                this._cancellable,
                 (selection, res) => {
                     try {
                         selection.transfer_finish(res);
@@ -347,6 +350,9 @@ var Clipboard = GObject.registerClass({
     }
 
     destroy() {
+        if (!this._cancellable.is_cancelled())
+            this._cancellable.cancel();
+
         if (this._transferring) {
             GLib.Source.remove(this._transferring);
             this._transferring = null;


### PR DESCRIPTION
There are a couple potential concurrent issues in the Clipboard which
could result in functions calling back to an instance after it has been
finalized.

This pull request attempts to address those issues by being careful to
remove pending GSources and adding an instance cancellable.