### PR TITLE
refactor(clipboard): synchronize with Valent

### DIFF
--- a/src/plugin/gnome-shell/__init__.py
+++ b/src/plugin/gnome-shell/__init__.py
@@ -30,6 +30,7 @@ class ValentGsClipboardAdapter(Valent.ClipboardAdapter):
         Valent.ClipboardAdapter.__init__(self)
 
         self.proxy = None
+        self.mimetypes = []
         self.timestamp = 0
         Gio.DBusProxy.new_for_bus(Gio.BusType.SESSION,
                                   Gio.DBusProxyFlags.DO_NOT_AUTO_START,
@@ -48,13 +49,99 @@ class ValentGsClipboardAdapter(Valent.ClipboardAdapter):
         except GLib.Error as error:
             print(repr(error))
 
-    def _on_g_signal(self, _proxy, _sender_name, signal_name, _parameters):
+    def _on_g_signal(self, _proxy, _sender_name, signal_name, parameters):
         if self.proxy is None or self.proxy.props.g_name_owner is None:
             return
 
         if signal_name == 'Changed':
-            self.timestamp = Valent.timestamp_ms()
+            metadata = parameters[0]
+            self.mimetypes = metadata.get('mimetypes', [])
+            self.timestamp = metadata.get('timestamp', Valent.timestamp_ms())
             self.emit_changed()
+
+    def do_get_mimetypes(self):
+        """
+        Implementation of :meth:`~Valent.ClipboardAdapter.get_mimetypes`.
+        """
+
+        return self.mimetypes
+
+    def do_get_timestamp(self):
+        """
+        Implementation of :meth:`~Valent.ClipboardAdapter.get_timestamp`.
+        """
+
+        return self.timestamp
+
+    def _get_bytes_cb(self, proxy, result, task):
+        try:
+            data = proxy.call_finish(result)[0]
+            value = GObject.Value(GObject.TYPE_BYTES, GLib.Bytes(data))
+            task.return_value(value)
+        except GLib.Error as error:
+            task.return_error(error)
+
+    def do_read_bytes(self, cancellable, callback, _user_data):
+        """
+        Implementation of :meth:`~Valent.ClipboardAdapter.read_bytes`.
+        """
+
+        # FIXME: we're swallowing `user_data`, since it can't be passed back
+        #        into libvalent by libpeas (yet)
+        task = Gio.Task.new(self, cancellable, callback)
+
+        if self.proxy is None or self.proxy.props.g_name_owner is None:
+            error = GLib.Error.new_literal(Gio.dbus_error_quark(),
+                                           'GNOME Shell extension disabled',
+                                           Gio.DBusError.NAME_HAS_NO_OWNER)
+            task.return_error(error)
+            return
+
+        self.proxy.call('GetBytes',
+                        None,
+                        Gio.DBusCallFlags.NO_AUTO_START,
+                        -1,
+                        cancellable,
+                        self._get_bytes_cb,
+                        task)
+
+    def do_read_bytes_finish(self, result):
+        """
+        Implementation of :meth:`~Valent.ClipboardAdapter.read_bytes_finish`.
+        """
+
+        return result.propagate_value()[1]
+
+    def _set_bytes_cb(self, proxy, result, task):
+        try:
+            proxy.call_finish(result)
+            task.return_boolean(True)
+        except GLib.Error as error:
+            task.return_error(error)
+
+    def do_write_bytes(self, mimetype, gbytes, cancellable, callback, _user_data):
+        """
+        Implementation of :meth:`~Valent.ClipboardAdapter.write_bytes`.
+        """
+
+        # FIXME: we're swallowing `user_data`, since it can't be passed back
+        #        into libvalent by libpeas (yet)
+        task = Gio.Task.new(self, cancellable, callback)
+
+        if self.proxy is None or self.proxy.props.g_name_owner is None:
+            error = GLib.Error.new_literal(Gio.dbus_error_quark(),
+                                           'GNOME Shell extension disabled',
+                                           Gio.DBusError.NAME_HAS_NO_OWNER)
+            task.return_error(error)
+            return
+
+        self.proxy.call('SetBytes',
+                        GLib.Variant('(say)', (mimetype, gbytes.get_data(),)),
+                        Gio.DBusCallFlags.NONE,
+                        -1,
+                        cancellable,
+                        self._set_bytes_cb,
+                        task)
 
     def _get_text_cb(self, proxy, result, task):
         try:
@@ -64,15 +151,9 @@ class ValentGsClipboardAdapter(Valent.ClipboardAdapter):
         except GLib.Error as error:
             task.return_error(error)
 
-    def _set_text_cb(self, proxy, result, task):
-        try:
-            proxy.call_finish(result)
-        except GLib.Error as error:
-            print(repr(error))
-
-    def do_get_text_async(self, cancellable, callback, _user_data):
+    def do_read_text(self, cancellable, callback, _user_data):
         """
-        Implementation of :meth:`~Valent.ClipboardAdapter.get_text_async`.
+        Implementation of :meth:`~Valent.ClipboardAdapter.read_text`.
         """
 
         # FIXME: we're swallowing `user_data`, since it can't be passed back
@@ -94,35 +175,43 @@ class ValentGsClipboardAdapter(Valent.ClipboardAdapter):
                         self._get_text_cb,
                         task)
 
-    def do_get_text_finish(self, result):
+    def do_read_text_finish(self, result):
         """
-        Implementation of :meth:`~Valent.ClipboardAdapter.get_text_finish`.
+        Implementation of :meth:`~Valent.ClipboardAdapter.read_text_finish`.
         """
 
         return result.propagate_value()[1]
 
-    def do_set_text(self, text):
+    def _set_text_cb(self, proxy, result, task):
+        try:
+            proxy.call_finish(result)
+            task.return_boolean(True)
+        except GLib.Error as error:
+            task.return_error(error)
+
+    def do_write_text(self, text, cancellable, callback, _user_data):
         """
         Implementation of :meth:`~Valent.ClipboardAdapter.set_text`.
         """
 
+        # FIXME: we're swallowing `user_data`, since it can't be passed back
+        #        into libvalent by libpeas (yet)
+        task = Gio.Task.new(self, cancellable, callback)
+
         if self.proxy is None or self.proxy.props.g_name_owner is None:
+            error = GLib.Error.new_literal(Gio.dbus_error_quark(),
+                                           'GNOME Shell extension disabled',
+                                           Gio.DBusError.NAME_HAS_NO_OWNER)
+            task.return_error(error)
             return
 
         self.proxy.call('SetText',
                         GLib.Variant('(s)', (text,)),
                         Gio.DBusCallFlags.NONE,
                         -1,
-                        None,
-                        None,
-                        None)
-
-    def do_get_timestamp(self):
-        """
-        Implementation of :meth:`~Valent.ClipboardAdapter.get_timestamp`.
-        """
-
-        return self.timestamp
+                        cancellable,
+                        self._set_text_cb,
+                        task)
 
 
 class ValentGsSessionAdapter(Valent.SessionAdapter):


### PR DESCRIPTION
* refactor `GetValue()`/`SetValue()` as `GetBytes()`/`SetBytes()`
* refactor `Changed` to include a metadata parameter; a dictionary with
  mimetypes and timestamp
* add `GetMimetypes()`