### PR TITLE
ci: use container image from current repository

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ jobs:
     name: Extension
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/gnome-shell-extension-valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     needs: [pre-test]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/andyholmes/gnome-shell-extension-valent:latest
+      image: ghcr.io/${{ github.repository }}:latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Modify workflows to use `${{ github.repository }}` in place of `andyholmes/gnome-shell-extension-valent`, so that forks can pull their own images if they make relevant changes.