### PR TITLE
feat: support opening device pages from the menu

### DIFF
--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: gnome-shell-extension-valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/gnome-shell-extension-"
 "valent/issues\n"
-"POT-Creation-Date: 2022-09-06 22:25-0700\n"
+"POT-Creation-Date: 2022-09-06 22:47-0700\n"
 "PO-Revision-Date: 2022-01-16 01:10-0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -29,21 +29,21 @@ msgid "Type a message"
 msgstr "Type a message"
 
 #. TRANSLATORS: The quick settings item label
-#: src/extension/status.js:248 src/extension/status.js:333
+#: src/extension/status.js:247 src/extension/status.js:338
 msgid "Valent"
 msgstr "Valent"
 
-#: src/extension/status.js:259
+#: src/extension/status.js:258
 msgid "Device Connections"
 msgstr "Device Connections"
 
 #. TRANSLATORS: A menu option to open the main window
-#: src/extension/status.js:268
+#: src/extension/status.js:267
 msgid "All Devices"
 msgstr "All Devices"
 
 #. TRANSLATORS: %d is the number of devices connected
-#: src/extension/status.js:329
+#: src/extension/status.js:334
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"

--- a/po/en.po
+++ b/po/en.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: gnome-shell-extension-valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/gnome-shell-extension-"
 "valent/issues\n"
-"POT-Creation-Date: 2022-09-06 13:49-0700\n"
+"POT-Creation-Date: 2022-09-06 22:25-0700\n"
 "PO-Revision-Date: 2022-01-16 01:10-0800\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -29,21 +29,21 @@ msgid "Type a message"
 msgstr "Type a message"
 
 #. TRANSLATORS: The quick settings item label
-#: src/extension/status.js:248 src/extension/status.js:342
+#: src/extension/status.js:248 src/extension/status.js:333
 msgid "Valent"
-msgstr ""
+msgstr "Valent"
 
 #: src/extension/status.js:259
 msgid "Device Connections"
-msgstr ""
+msgstr "Device Connections"
 
-#. TRANSLATORS: A menu option to open the service settings
+#. TRANSLATORS: A menu option to open the main window
 #: src/extension/status.js:268
-msgid "Valent Settings"
-msgstr "Valent Settings"
+msgid "All Devices"
+msgstr "All Devices"
 
 #. TRANSLATORS: %d is the number of devices connected
-#: src/extension/status.js:338
+#: src/extension/status.js:329
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"

--- a/po/gnome-shell-extension-valent.pot
+++ b/po/gnome-shell-extension-valent.pot
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: gnome-shell-extension-valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/gnome-shell-extension-"
 "valent/issues\n"
-"POT-Creation-Date: 2022-09-06 22:25-0700\n"
+"POT-Creation-Date: 2022-09-06 22:47-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,21 +30,21 @@ msgid "Type a message"
 msgstr ""
 
 #. TRANSLATORS: The quick settings item label
-#: src/extension/status.js:248 src/extension/status.js:333
+#: src/extension/status.js:247 src/extension/status.js:338
 msgid "Valent"
 msgstr ""
 
-#: src/extension/status.js:259
+#: src/extension/status.js:258
 msgid "Device Connections"
 msgstr ""
 
 #. TRANSLATORS: A menu option to open the main window
-#: src/extension/status.js:268
+#: src/extension/status.js:267
 msgid "All Devices"
 msgstr ""
 
 #. TRANSLATORS: %d is the number of devices connected
-#: src/extension/status.js:329
+#: src/extension/status.js:334
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"

--- a/po/gnome-shell-extension-valent.pot
+++ b/po/gnome-shell-extension-valent.pot
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: gnome-shell-extension-valent\n"
 "Report-Msgid-Bugs-To: https://github.com/andyholmes/gnome-shell-extension-"
 "valent/issues\n"
-"POT-Creation-Date: 2022-09-06 13:49-0700\n"
+"POT-Creation-Date: 2022-09-06 22:25-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgid "Type a message"
 msgstr ""
 
 #. TRANSLATORS: The quick settings item label
-#: src/extension/status.js:248 src/extension/status.js:342
+#: src/extension/status.js:248 src/extension/status.js:333
 msgid "Valent"
 msgstr ""
 
@@ -38,13 +38,13 @@ msgstr ""
 msgid "Device Connections"
 msgstr ""
 
-#. TRANSLATORS: A menu option to open the service settings
+#. TRANSLATORS: A menu option to open the main window
 #: src/extension/status.js:268
-msgid "Valent Settings"
+msgid "All Devices"
 msgstr ""
 
 #. TRANSLATORS: %d is the number of devices connected
-#: src/extension/status.js:338
+#: src/extension/status.js:329
 #, javascript-format
 msgid "%d Connected"
 msgid_plural "%d Connected"

--- a/src/extension/status.js
+++ b/src/extension/status.js
@@ -185,7 +185,6 @@ const DeviceMenuItem = GObject.registerClass({
 
         // Workaround parameter parsing
         this.device = device;
-        this._activatable = false;
 
         this._icon = new St.Icon({
             fallback_icon_name: 'computer-symbolic',
@@ -292,8 +291,14 @@ const MenuToggle = GObject.registerClass({
         this.service.disconnect(this._deviceRemovedId);
     }
 
+    _onDeviceActivated(item) {
+        const target = item.device.get_cached_property('Id');
+        this.service.activate_action('window', target);
+    }
+
     _onDeviceAdded(_service, device) {
         const menuItem = new DeviceMenuItem(device);
+        menuItem.connect('activate', this._onDeviceActivated.bind(this));
         this._devicesSection.addMenuItem(menuItem);
 
         const stateChangedId = device.connect('notify::state',

--- a/src/extension/status.js
+++ b/src/extension/status.js
@@ -264,11 +264,9 @@ const MenuToggle = GObject.registerClass({
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
-        // TRANSLATORS: A menu option to open the service settings
-        const settingsItem = this.menu.addAction(_('Valent Settings'),
-            this._onSettingsActivated.bind(this));
-        settingsItem.visible = Main.sessionMode.allowSettings;
-        this.menu._settingsActions['ca.andyholme.Valent.desktop'] = settingsItem;
+        // TRANSLATORS: A menu option to open the main window
+        this.menu.addSettingsAction(_('All Devices'),
+            'ca.andyholmes.Valent.desktop');
 
         this._activeChangedId = this.service.connect('notify::active',
             this._sync.bind(this));
@@ -316,13 +314,6 @@ const MenuToggle = GObject.registerClass({
 
         this._devices.delete(device);
         this._sync();
-    }
-
-    _onSettingsActivated(_event) {
-        this.service.activate_action('preferences');
-
-        Main.overview.hide();
-        Main.panel.closeQuickSettings();
     }
 
     _sync() {


### PR DESCRIPTION
Support opening device pages from their menu items, and use the standard
method for opening the main window.

Depends on andyholmes/valent#245