### PR TITLE
refactor(remote): another attempt to solve race conditions

### DIFF
--- a/src/extension/status.js
+++ b/src/extension/status.js
@@ -378,9 +378,6 @@ var Indicator = GObject.registerClass({
         QuickSettingsMenu._addItems(this.quickSettingsItems);
         QuickSettingsMenu._indicators.insert_child_at_index(this, 0);
         this.connect('destroy', this._onDestroy.bind(this));
-
-        // Prime the service
-        this._service.sync();
     }
 
     _onDestroy(_actor) {


### PR DESCRIPTION
Rewrite the service proxy to avoid use of async/await or `Promise()`, which can have weird race conditions. This also allows removing the `Remote.Service.sync()` method.