### PR TITLE
refactor(remote): another attempt to solve race conditions

### DIFF
--- a/src/extension/extension.js
+++ b/src/extension/extension.js
@@ -120,9 +120,6 @@ const ServiceIndicator = GObject.registerClass({
         // TRANSLATORS: A menu option to open the main window
         this._item.menu.addSettingsAction(_('All Devices'),
             'ca.andyholmes.Valent.desktop');
-
-        // Prime the service
-        this.service.sync();
     }
 
     _onDestroy(actor) {


### PR DESCRIPTION
Rewrite the service proxy to avoid use of async/await or `Promise()`, which can have weird race conditions. This also allows removing the `Remote.Service.sync()` method.