### PR TITLE
fix: remove uneeded toggle-mode

### DIFF
--- a/src/extension/status.js
+++ b/src/extension/status.js
@@ -245,7 +245,6 @@ const MenuToggle = GObject.registerClass({
     constructor(params = {}) {
         super({
             label: _('Valent'),
-            toggle_mode: true,
             ...params,
         });
 


### PR DESCRIPTION
We handle the `QuickMenuToggle:checked` state ourselves, so having `toggle-mode` enabled can only cause problems.