### PR TITLE
refactor(status): remove the construct-time `label` value

### DIFF
--- a/src/extension/status.js
+++ b/src/extension/status.js
@@ -243,10 +243,7 @@ const MenuToggle = GObject.registerClass({
     },
 }, class MenuToggle extends QuickSettings.QuickMenuToggle {
     constructor(params = {}) {
-        super({
-            label: _('Valent'),
-            ...params,
-        });
+        super(params);
 
         this._activeIcon = Gio.Icon.new_for_string(
             `file://${Extension.path}/data/phonelink-symbolic.svg`);


### PR DESCRIPTION
GNOME Shell 44 has renamed `QuickMenuToggle:label` to `title`, and although there are deprecated accessors, these don't work for construct properties.

Remove the subclass's default value for the `label` property, since it's synced before the constructor returns anyways.