### PR TITLE
GNOME 44 Support

### DIFF
--- a/src/extension/metadata.json.in
+++ b/src/extension/metadata.json.in
@@ -5,6 +5,6 @@
     "gettext-domain": "@GETTEXT_DOMAIN@",
     "version": @EXTENSION_VERSION@,
     "session-modes": ["unlock-dialog", "user"],
-    "shell-version": ["43"],
+    "shell-version": ["44"],
     "url": "https://github.com/andyholmes/gnome-shell-extension-valent"
 }

--- a/src/extension/status.js
+++ b/src/extension/status.js
@@ -330,14 +330,14 @@ const MenuToggle = GObject.registerClass({
         });
 
         if (available.length === 1) {
-            this.label = available[0].name;
+            this.title = available[0].name;
         } else if (available.length > 0) {
             // TRANSLATORS: %d is the number of devices connected
-            this.label = ngettext('%d Connected', '%d Connected',
+            this.title = ngettext('%d Connected', '%d Connected',
                 available.length).format(available.length);
         } else {
             // TRANSLATORS: The quick settings item label
-            this.label = _('Valent');
+            this.title = _('Valent');
         }
 
         this.checked = this.service.active;


### PR DESCRIPTION
Bump the `shell-version` in `metadata.json` to `"44"`, in lieu of the March release of GNOME 44.

closes #51