### PR TITLE
fix(extension): correct placement of the quick settings tile

### DIFF
--- a/src/extension/status.js
+++ b/src/extension/status.js
@@ -374,9 +374,19 @@ var Indicator = GObject.registerClass({
         const menuToggle = new MenuToggle({ service: this._service });
         this.quickSettingsItems.push(menuToggle);
 
-        QuickSettingsMenu._addItems(this.quickSettingsItems);
+        this._addItems(this.quickSettingsItems);
         QuickSettingsMenu._indicators.insert_child_at_index(this, 0);
         this.connect('destroy', this._onDestroy.bind(this));
+    }
+
+    _addItems(items) {
+        QuickSettingsMenu._addItems(items);
+
+        // Ensure the tile(s) are above the background apps menu
+        for (const item of items) {
+            QuickSettingsMenu.menu._grid.set_child_below_sibling(item,
+                QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
+        }
     }
 
     _onDestroy(_actor) {


### PR DESCRIPTION
The new background apps menu has a different appearance than other quick settings items, making it really look best on the bottom.

After adding the quick settings tile with the supplied method, move the tile above the backgrounds app menu without disturbing anything GNOME Shell expects.