### PR TITLE
refactor: port to static class declarations

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -25,9 +25,11 @@ const _pushNotification = NotificationDaemon.GtkNotificationDaemonAppSource.prot
 /**
  * A slightly modified Notification Banner with an entry field
  */
-const NotificationBanner = GObject.registerClass({
-    GTypeName: 'ValentNotificationBanner',
-}, class NotificationBanner extends MessageTray.NotificationBanner {
+class NotificationBanner extends MessageTray.NotificationBanner {
+    static {
+        GObject.registerClass(this);
+    }
+
     constructor(notification) {
         super(notification);
 
@@ -160,7 +162,7 @@ const NotificationBanner = GObject.registerClass({
         this._closed = true;
         this.destroy();
     }
-});
+}
 
 
 /**
@@ -168,9 +170,11 @@ const NotificationBanner = GObject.registerClass({
  * notifications. This source is never instantiated; it's methods are patched
  * into existing sources.
  */
-const Source = GObject.registerClass({
-    GTypeName: 'ValentNotificationSource',
-}, class Source extends NotificationDaemon.GtkNotificationDaemonAppSource {
+class Source extends NotificationDaemon.GtkNotificationDaemonAppSource {
+    static {
+        GObject.registerClass(this);
+    }
+
     _valentCloseNotification(notification, reason) {
         if (reason !== MessageTray.NotificationDestroyedReason.DISMISSED)
             return;
@@ -292,7 +296,7 @@ const Source = GObject.registerClass({
     createBanner(notification) {
         return new NotificationBanner(notification);
     }
-});
+}
 
 
 let _sourceAddedId = null;

--- a/src/remote.js
+++ b/src/remote.js
@@ -32,41 +32,25 @@ var DeviceState = Object.freeze({
 /**
  * A simple proxy wrapper for devices exported over DBus.
  */
-var Device = GObject.registerClass({
-    GTypeName: 'ValentRemoteDevice',
-    Implements: [Gio.DBusInterface],
-    Properties: {
-        'icon-name': GObject.ParamSpec.string(
-            'icon-name',
-            'Icon Name',
-            'A symbolic icon name for the device',
-            GObject.ParamFlags.READABLE,
-            null
-        ),
-        'id': GObject.ParamSpec.string(
-            'id',
-            'ID',
-            'A unique ID for the device',
-            GObject.ParamFlags.READABLE,
-            null
-        ),
-        'name': GObject.ParamSpec.string(
-            'name',
-            'Name',
-            'A display name for the device',
-            GObject.ParamFlags.READABLE,
-            null
-        ),
-        'state': GObject.ParamSpec.uint(
-            'state',
-            'State',
-            'The state of the device',
+var Device = class Device extends Gio.DBusProxy {
+    static [GObject.interfaces] = [Gio.DBusInterface];
+    static [GObject.properties] = {
+        'icon-name': GObject.ParamSpec.string('icon-name', null, null,
+            GObject.ParamFlags.READABLE, null),
+        'id': GObject.ParamSpec.string('id', null, null,
+            GObject.ParamFlags.READABLE, null),
+        'name': GObject.ParamSpec.string('name', null, null,
+            GObject.ParamFlags.READABLE, null),
+        'state': GObject.ParamSpec.uint('state', null, null,
             GObject.ParamFlags.READABLE,
             DeviceState.NONE, DeviceState.CONNECTED | DeviceState.PAIRED_OUTGOING,
-            DeviceState.NONE
-        ),
-    },
-}, class Device extends Gio.DBusProxy {
+            DeviceState.NONE),
+    };
+
+    static {
+        GObject.registerClass(this);
+    }
+
     constructor(params = {}) {
         super({
             g_interface_name: 'ca.andyholmes.Valent.Device',
@@ -119,25 +103,23 @@ var Device = GObject.registerClass({
     get state() {
         return this._get('State', DeviceState.NONE);
     }
-});
+};
 
 
 /**
  * A simple proxy wrapper for the GSConnect service.
  */
-var Service = GObject.registerClass({
-    GTypeName: 'ValentRemoteService',
-    Implements: [Gio.DBusInterface, Gio.ListModel],
-    Properties: {
-        'active': GObject.ParamSpec.boolean(
-            'active',
-            'Active',
-            'Whether the service is active',
-            GObject.ParamFlags.READABLE,
-            false
-        ),
-    },
-}, class Service extends Gio.DBusProxy {
+var Service = class Service extends Gio.DBusProxy {
+    static [GObject.interfaces] = [Gio.DBusInterface, Gio.ListModel];
+    static [GObject.properties] = {
+        'active': GObject.ParamSpec.boolean('active', null, null,
+            GObject.ParamFlags.READABLE, false),
+    };
+
+    static {
+        GObject.registerClass(this);
+    }
+
     constructor() {
         super({
             g_bus_type: Gio.BusType.SESSION,
@@ -406,5 +388,5 @@ var Service = GObject.registerClass({
             this._active = false;
         }
     }
-});
+};
 

--- a/src/status.js
+++ b/src/status.js
@@ -45,18 +45,16 @@ function _getBatteryIcon(percentage, charging) {
 /**
  * A battery widget with an icon and text percentage.
  */
-const DeviceBattery = GObject.registerClass({
-    GTypeName: 'ValentDeviceBattery',
-    Properties: {
-        'device': GObject.ParamSpec.object(
-            'device',
-            'Device',
-            'The remote device',
-            GObject.ParamFlags.READWRITE,
-            Remote.Device
-        ),
-    },
-}, class DeviceBattery extends St.BoxLayout {
+class DeviceBattery extends St.BoxLayout {
+    static [GObject.properties] = {
+        'device': GObject.ParamSpec.object('device', null, null,
+            GObject.ParamFlags.READWRITE, Remote.Device),
+    };
+
+    static {
+        GObject.registerClass(this);
+    }
+
     constructor(params = {}) {
         super({
             style_class: 'valent-device-battery',
@@ -161,24 +159,22 @@ const DeviceBattery = GObject.registerClass({
         for (const handlerId of this._actionHandlerIds)
             this.device.action_group.disconnect(handlerId);
     }
-});
+}
 
 
 /**
  * A menu item for devices.
  */
-const DeviceMenuItem = GObject.registerClass({
-    GTypeName: 'ValentDeviceMenuItem',
-    Properties: {
-        'device': GObject.ParamSpec.object(
-            'device',
-            'Device',
-            'The remote device',
-            GObject.ParamFlags.READWRITE,
-            Remote.Device
-        ),
-    },
-}, class DeviceMenuItem extends PopupMenu.PopupBaseMenuItem {
+class DeviceMenuItem extends PopupMenu.PopupBaseMenuItem {
+    static [GObject.properties] = {
+        'device': GObject.ParamSpec.object('device', null, null,
+            GObject.ParamFlags.READWRITE, Remote.Device),
+    };
+
+    static {
+        GObject.registerClass(this);
+    }
+
     constructor(device) {
         super();
 
@@ -223,24 +219,22 @@ const DeviceMenuItem = GObject.registerClass({
         this.visible = (device.state & Remote.DeviceState.CONNECTED) !== 0 &&
                        (device.state & Remote.DeviceState.PAIRED) !== 0;
     }
-});
+}
 
 
 /**
  * The quick settings menu for Valent.
  */
-const MenuToggle = GObject.registerClass({
-    GTypeName: 'ValentMenuToggle',
-    Properties: {
-        'service': GObject.ParamSpec.object(
-            'service',
-            'Service',
-            'The remote service',
-            GObject.ParamFlags.READWRITE,
-            Remote.Service.$gtype
-        ),
-    },
-}, class MenuToggle extends QuickSettings.QuickMenuToggle {
+class MenuToggle extends QuickSettings.QuickMenuToggle {
+    static [GObject.properties] = {
+        'service': GObject.ParamSpec.object('service', null, null,
+            GObject.ParamFlags.READWRITE, Remote.Service),
+    };
+
+    static {
+        GObject.registerClass(this);
+    }
+
     constructor(params = {}) {
         super(params);
 
@@ -408,15 +402,17 @@ const MenuToggle = GObject.registerClass({
         this._serviceItem.label.text = serviceLabel;
         this._serviceItem.setIcon(serviceIcon);
     }
-});
+}
 
 
 /**
  * The service indicator for Valent.
  */
-var Indicator = GObject.registerClass({
-    GTypeName: 'ValentIndicator',
-}, class Indicator extends QuickSettings.SystemIndicator {
+var Indicator = class Indicator extends QuickSettings.SystemIndicator {
+    static {
+        GObject.registerClass(this);
+    }
+
     constructor() {
         super();
 
@@ -482,5 +478,5 @@ var Indicator = GObject.registerClass({
 
         this._icon.visible = connectedDevices.length > 0;
     }
-});
+};
 


### PR DESCRIPTION
Since gjs-1.72, there has been support for various `static` class declaration fields for GObject subclasses.

Port to use these new features, which are a bit cleaner and probably easy to migrate to when decorators arrive.