### PR TITLE
fix(notification): use correct arguments for method override

### DIFF
--- a/src/notification.js
+++ b/src/notification.js
@@ -321,12 +321,11 @@ class _NotificationMessageGroup {
      * This ensures device notifications that support replies are given a
      * custom `MessageList.NotificationMessage` with a reply button and entry.
      *
-     * @param {MessageList.Source} source - an event source
      * @param {MessageTray.Notification} - an event notification
      */
-    _addNotification(source, notification) {
+    _addNotification(notification) {
         // valent-modifications-begin
-        const message = source?._appId === APPLICATION_ID
+        const message = this?.source?._appId === APPLICATION_ID
             ? new NotificationMessage(notification)
             : new MessageList.NotificationMessage(notification);
         // valent-modifications-end


### PR DESCRIPTION
Use the correct arguments for the `NotificationMessageGroup` override, which have changed since GNOME Shell 48.0.

closes #124